### PR TITLE
Unquoted opts in Filesystem macro so they can be read from the enviro…

### DIFF
--- a/test/depot_test.exs
+++ b/test/depot_test.exs
@@ -369,6 +369,25 @@ defmodule DepotTest do
       {:ok, filesystem: filesystem}
     end
 
+    test "reads configuration from :otp_app" do
+      prefix = "ziKK7t5LzV5XiJjYh30KxCLorRXqLwwEnZYJ"
+
+      configuration = [
+        adapter: Depot.Adapter.Local,
+        prefix: prefix
+      ]
+
+      Application.put_env(:depot_test, DepotTest.AdhocFilesystem, configuration)
+
+      defmodule AdhocFilesystem do
+        use Depot.Filesystem, otp_app: :depot_test
+      end
+
+      {_module, module_config} = DepotTest.AdhocFilesystem.__filesystem__()
+
+      assert module_config.prefix == prefix
+    end
+
     test "directory traversals are detected and reported", %{filesystem: filesystem} do
       {:error, {:path, :traversal}} = Depot.write(filesystem, "../test.txt", "Hello World")
       {:error, {:path, :traversal}} = Depot.read(filesystem, "../test.txt")

--- a/test/depot_test.exs
+++ b/test/depot_test.exs
@@ -370,11 +370,9 @@ defmodule DepotTest do
     end
 
     test "reads configuration from :otp_app" do
-      prefix = "ziKK7t5LzV5XiJjYh30KxCLorRXqLwwEnZYJ"
-
       configuration = [
         adapter: Depot.Adapter.Local,
-        prefix: prefix
+        prefix: "ziKK7t5LzV5XiJjYh30KxCLorRXqLwwEnZYJ"
       ]
 
       Application.put_env(:depot_test, DepotTest.AdhocFilesystem, configuration)
@@ -385,7 +383,7 @@ defmodule DepotTest do
 
       {_module, module_config} = DepotTest.AdhocFilesystem.__filesystem__()
 
-      assert module_config.prefix == prefix
+      assert module_config.prefix == "ziKK7t5LzV5XiJjYh30KxCLorRXqLwwEnZYJ"
     end
 
     test "directory traversals are detected and reported", %{filesystem: filesystem} do


### PR DESCRIPTION
First and foremost:
Thank you for creating this library. I've been looking **exactly** for this and couldn't find it a month ago.

Changes:
I've unquoted `opts` in the filesystem macro, so we can theoretically pass them from the environment as `use Depot.Filesystem, Application.get_env(:visum, __MODULE__)`.

In order to facilitate the retrieval of `opts` from the environment, I've added `:otp_app` as possible key, so that the configuration can stay in the conf-files.

Filesystem:
```elixir
defmodule Demo.Filesystem do
  use Depot.Filesystem, otp_app: :demo
end
```

config:
```elixir
config :demo, Demo.Filesystem,
       adapter: DepotS3,
       bucket: "documents",
       config: [
         access_key_id: "minioadmin",
         secret_access_key: "minioadmin",
         scheme: "http://",
         region: "local",
         host: "127.0.0.1",
         port: 9000
       ]
```

Besides that I've added `@behaviour Depot.Filesystem` in the `__using__` function of the macro. However I'm not sure if that's a brilliant idea.

Cheers,
Alex