### PR TITLE
Add read_stream function (missing implementation in memory adapter)

### DIFF
--- a/lib/depot.ex
+++ b/lib/depot.ex
@@ -64,6 +64,12 @@ defmodule Depot do
     end
   end
 
+  def read_stream({adapter, config}, path, _opts \\ []) do
+    with {:ok, path} <- Depot.RelativePath.normalize(path) do
+      adapter.read_stream(config, path)
+    end
+  end
+
   @doc """
   Delete a file from a filesystem
 

--- a/lib/depot/adapter.ex
+++ b/lib/depot/adapter.ex
@@ -9,6 +9,7 @@ defmodule Depot.Adapter do
   @callback configure(keyword) :: {module(), config}
   @callback write(config, path, contents :: iodata()) :: :ok | {:error, term}
   @callback read(config, path) :: {:ok, binary} | {:error, term}
+  @callback read_stream(config, path) :: {:ok, Enumerable.t()} | {:error, term}
   @callback delete(config, path) :: :ok | {:error, term}
   @callback move(config, source :: path, destination :: path) :: :ok | {:error, term}
   @callback copy(config, source :: path, destination :: path) :: :ok | {:error, term}

--- a/lib/depot/adapter/local.ex
+++ b/lib/depot/adapter/local.ex
@@ -55,6 +55,15 @@ defmodule Depot.Adapter.Local do
   end
 
   @impl Depot.Adapter
+  def read_stream(%Config{} = config, path) do
+    try do
+      {:ok, File.stream!(full_path(config, path))}
+    rescue
+      e -> {:error, e}
+    end
+  end
+
+  @impl Depot.Adapter
   def delete(%Config{} = config, path) do
     with {:error, :enoent} <- File.rm(full_path(config, path)), do: :ok
   end

--- a/lib/depot/filesystem.ex
+++ b/lib/depot/filesystem.ex
@@ -46,6 +46,10 @@ defmodule Depot.Filesystem do
         do: Depot.read(@filesystem, path, opts)
 
       @impl true
+      def read_stream(path, opts \\ []),
+          do: Depot.read_stream(@filesystem, path, opts)
+
+      @impl true
       def delete(path, opts \\ []),
         do: Depot.delete(@filesystem, path, opts)
 


### PR DESCRIPTION
Adding `read_stream` as in my use case I needed to stream files from S3 (`DepotS3` PR incoming).
However it's missing the implementation in the `Memory` adapter.

In order to complete the `stream` set of functions of Flysystem, these function would still need to be implemented:
- `write_stream`
- `update_stream`
- `put_stream`

Besides these IMHO it'd be a good idea to have a stream-version of `list_contents` as well, as the amount of objects within an S3 bucket can grow enormously.