### PR TITLE
Fix dialyzer issues

### DIFF
--- a/lib/depot/adapter.ex
+++ b/lib/depot/adapter.ex
@@ -5,7 +5,7 @@ defmodule Depot.Adapter do
   @type path :: Path.t()
   @type stream_opts :: keyword
   @type directory_delete_opts :: keyword
-  @opaque config :: struct
+  @type config :: struct
 
   @callback starts_processes() :: boolean
   @callback configure(keyword) :: {module(), config}


### PR DESCRIPTION
I'm experiencing issues with dialyzer on my build pipeline due to `Depot.Adapter.config` being defined as opaque.
Replacing `@opaque` with `@type` solves this.

```
Total errors: 21, Skipped: 0, Unnecessary Skips: 0
done in 0m12.47s
lib/images/filesystem.ex:4:no_return
Function copy/2 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:no_return
Function copy/3 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:call_without_opaque
Function call without opaqueness type mismatch.

Call does not have expected term of type {atom(), Depot.Adapter.config()} (with opaque subterms) in the 1st position.

Depot.copy(
  {Depot.Adapter.Local,
   %Depot.Adapter.Local.Config{
     :prefix => <<100, 97, 116, 97, 47, 105, 109, 97, 103, 101, 115>>
   }},
  _ :: any(),
  _ :: any(),
  _ :: any()
)

________________________________________________________________________________
lib/images/filesystem.ex:4:no_return
Function delete/1 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:no_return
Function delete/2 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:call_without_opaque
Function call without opaqueness type mismatch.

Call does not have expected term of type {atom(), Depot.Adapter.config()} (with opaque subterms) in the 1st position.

Depot.delete(
  {Depot.Adapter.Local,
   %Depot.Adapter.Local.Config{
     :prefix => <<100, 97, 116, 97, 47, 105, 109, 97, 103, 101, 115>>
   }},
  _ :: any(),
  _ :: any()
)

________________________________________________________________________________
lib/images/filesystem.ex:4:no_return
Function file_exists/1 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:no_return
Function file_exists/2 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:call_without_opaque
Function call without opaqueness type mismatch.

Call does not have expected term of type {atom(), Depot.Adapter.config()} (with opaque subterms) in the 1st position.

Depot.file_exists(
  {Depot.Adapter.Local,
   %Depot.Adapter.Local.Config{
     :prefix => <<100, 97, 116, 97, 47, 105, 109, 97, 103, 101, 115>>
   }},
  _ :: any(),
  _ :: any()
)

________________________________________________________________________________
lib/images/filesystem.ex:4:no_return
Function list_contents/1 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:no_return
Function list_contents/2 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:call_without_opaque
Function call without opaqueness type mismatch.

Call does not have expected term of type {atom(), Depot.Adapter.config()} (with opaque subterms) in the 1st position.

Depot.list_contents(
  {Depot.Adapter.Local,
   %Depot.Adapter.Local.Config{
     :prefix => <<100, 97, 116, 97, 47, 105, 109, 97, 103, 101, 115>>
   }},
  _ :: any(),
  _ :: any()
)

________________________________________________________________________________
lib/images/filesystem.ex:4:no_return
Function move/2 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:no_return
Function move/3 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:call_without_opaque
Function call without opaqueness type mismatch.

Call does not have expected term of type {atom(), Depot.Adapter.config()} (with opaque subterms) in the 1st position.

Depot.move(
  {Depot.Adapter.Local,
   %Depot.Adapter.Local.Config{
     :prefix => <<100, 97, 116, 97, 47, 105, 109, 97, 103, 101, 115>>
   }},
  _ :: any(),
  _ :: any(),
  _ :: any()
)

________________________________________________________________________________
lib/images/filesystem.ex:4:no_return
Function read/1 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:no_return
Function read/2 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:call_without_opaque
Function call without opaqueness type mismatch.

Call does not have expected term of type {atom(), Depot.Adapter.config()} (with opaque subterms) in the 1st position.

Depot.read(
  {Depot.Adapter.Local,
   %Depot.Adapter.Local.Config{
     :prefix => <<100, 97, 116, 97, 47, 105, 109, 97, 103, 101, 115>>
   }},
  _ :: any(),
  _ :: any()
)

________________________________________________________________________________
lib/images/filesystem.ex:4:no_return
Function write/2 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:no_return
Function write/3 has no local return.
________________________________________________________________________________
lib/images/filesystem.ex:4:call_without_opaque
Function call without opaqueness type mismatch.

Call does not have expected term of type {atom(), Depot.Adapter.config()} (with opaque subterms) in the 1st position.

Depot.write(
  {Depot.Adapter.Local,
   %Depot.Adapter.Local.Config{
     :prefix => <<100, 97, 116, 97, 47, 105, 109, 97, 103, 101, 115>>
   }},
  _ :: any(),
  _ :: any(),
  _ :: any()
)

________________________________________________________________________________
done (warnings were emitted)
Halting VM with exit status 2
```