### PR TITLE
Replace briefly with tmp dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@
 # Where third-party dependencies like ExDoc output generated docs.
 /doc/
 
+# Temporary test files
+/tmp/
+
 # Ignore .fetch files in case you like to edit your project deps locally.
 /.fetch
 
@@ -21,4 +24,3 @@ erl_crash.dump
 
 # Ignore package tarball (built via "mix hex.build").
 depot-*.tar
-

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 - Added visibility handling with callbacks and converters
-
+### Changed
+- Updated Elixir to ~> 1.11
+- Replaced Briefly test dependency with ExUnit's :tmp_dir
 
 ## [0.5.1] - 2021-09-12
 ### Changed

--- a/lib/depot/adapter/local.ex
+++ b/lib/depot/adapter/local.ex
@@ -4,7 +4,7 @@ defmodule Depot.Adapter.Local do
 
   ## Direct usage
 
-      iex> {:ok, prefix} = Briefly.create(directory: true)
+      iex> prefix = System.tmp_dir!()
       iex> filesystem = Depot.Adapter.Local.configure(prefix: prefix)
       iex> :ok = Depot.write(filesystem, "test.txt", "Hello World")
       iex> {:ok, "Hello World"} = Depot.read(filesystem, "test.txt")

--- a/mix.exs
+++ b/mix.exs
@@ -53,12 +53,7 @@ defmodule Depot.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:ex_doc, "~> 0.21", only: :dev, runtime: false},
-      # Replace with ExUnit tmp_dir on 1.11
-      {
-        :briefly,
-        git: "https://github.com/CargoSense/briefly", ref: "06ac1a6", only: :test
-      }
+      {:ex_doc, "~> 0.21", only: :dev, runtime: false}
     ]
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Depot.MixProject do
     [
       app: :depot,
       version: "0.5.1",
-      elixir: "~> 1.10",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),

--- a/mix.lock
+++ b/mix.lock
@@ -1,6 +1,4 @@
 %{
-  "briefly": {:git, "https://github.com/CargoSense/briefly", "06ac1a6acf43e9f8d0e32da9c2fe6491866fe301", [ref: "06ac1a6"]},
-  "earmark": {:hex, :earmark, "1.4.4", "4821b8d05cda507189d51f2caeef370cf1e18ca5d7dfb7d31e9cafe6688106a4", [:mix], [], "hexpm", "1f93aba7340574847c0f609da787f0d79efcab51b044bb6e242cae5aca9d264d"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.15", "b29e8e729f4aa4a00436580dcc2c9c5c51890613457c193cc8525c388ccb2f06", [:mix], [], "hexpm", "044523d6438ea19c1b8ec877ec221b008661d3c27e3b848f4c879f500421ca5c"},
   "ex_doc": {:hex, :ex_doc, "0.25.2", "4f1cae793c4d132e06674b282f1d9ea3bf409bcca027ddb2fe177c4eed6a253f", [:mix], [{:earmark_parser, "~> 1.4.0", [hex: :earmark_parser, repo: "hexpm", optional: false]}, {:makeup_elixir, "~> 0.14", [hex: :makeup_elixir, repo: "hexpm", optional: false]}, {:makeup_erlang, "~> 0.1", [hex: :makeup_erlang, repo: "hexpm", optional: false]}], "hexpm", "5b0c172e87ac27f14dfd152d52a145238ec71a95efbf29849550278c58a393d6"},
   "makeup": {:hex, :makeup, "1.0.5", "d5a830bc42c9800ce07dd97fa94669dfb93d3bf5fcf6ea7a0c67b2e0e4a7f26c", [:mix], [{:nimble_parsec, "~> 0.5 or ~> 1.0", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "cfa158c02d3f5c0c665d0af11512fed3fba0144cf1aadee0f2ce17747fba2ca9"},

--- a/test/depot/adapter/local_test.exs
+++ b/test/depot/adapter/local_test.exs
@@ -4,22 +4,19 @@ defmodule Depot.Adapter.LocalTest do
   import Depot.AdapterTest
   doctest Depot.Adapter.Local
 
+  @moduletag :tmp_dir
+
   def match_mode(input, match) do
     (input &&& 0o777) == match
   end
 
-  setup do
-    {:ok, prefix} = Briefly.create(directory: true)
-    {:ok, prefix: prefix}
-  end
-
-  adapter_test %{prefix: prefix} do
+  adapter_test %{tmp_dir: prefix} do
     filesystem = Depot.Adapter.Local.configure(prefix: prefix)
     {:ok, filesystem: filesystem}
   end
 
   describe "write" do
-    test "success", %{prefix: prefix} do
+    test "success", %{tmp_dir: prefix} do
       {_, config} = Depot.Adapter.Local.configure(prefix: prefix)
 
       :ok = Depot.Adapter.Local.write(config, "test.txt", "Hello World", [])
@@ -27,7 +24,7 @@ defmodule Depot.Adapter.LocalTest do
       assert {:ok, "Hello World"} = File.read(Path.join(prefix, "test.txt"))
     end
 
-    test "folders are automatically created is missing", %{prefix: prefix} do
+    test "folders are automatically created is missing", %{tmp_dir: prefix} do
       {_, config} = Depot.Adapter.Local.configure(prefix: prefix)
 
       :ok = Depot.Adapter.Local.write(config, "folder/test.txt", "Hello World", [])
@@ -35,7 +32,7 @@ defmodule Depot.Adapter.LocalTest do
       assert {:ok, "Hello World"} = File.read(Path.join(prefix, "folder/test.txt"))
     end
 
-    test "stream options", %{prefix: prefix} do
+    test "stream options", %{tmp_dir: prefix} do
       {_, config} = Depot.Adapter.Local.configure(prefix: prefix)
 
       assert {:ok, %File.Stream{line_or_bytes: :line, modes: [:raw, :read_ahead, :binary]}} =
@@ -48,7 +45,7 @@ defmodule Depot.Adapter.LocalTest do
                Depot.Adapter.Local.write_stream(config, "test.txt", modes: [encoding: :utf8])
     end
 
-    test "stream success", %{prefix: prefix} do
+    test "stream success", %{tmp_dir: prefix} do
       {_, config} = Depot.Adapter.Local.configure(prefix: prefix)
 
       assert {:ok, %File.Stream{} = stream} =
@@ -59,7 +56,7 @@ defmodule Depot.Adapter.LocalTest do
       assert {:ok, "Hello World"} = File.read(Path.join(prefix, "test.txt"))
     end
 
-    test "default visibility", %{prefix: prefix} do
+    test "default visibility", %{tmp_dir: prefix} do
       {_, config} = Depot.Adapter.Local.configure(prefix: prefix)
 
       :ok = Depot.Adapter.Local.write(config, "public.txt", "Hello World", visibility: :public)
@@ -72,7 +69,7 @@ defmodule Depot.Adapter.LocalTest do
       assert match_mode(mode, 0o600)
     end
 
-    test "folder visibility", %{prefix: prefix} do
+    test "folder visibility", %{tmp_dir: prefix} do
       {_, config} = Depot.Adapter.Local.configure(prefix: prefix)
 
       :ok =
@@ -95,7 +92,7 @@ defmodule Depot.Adapter.LocalTest do
   end
 
   describe "read" do
-    test "success", %{prefix: prefix} do
+    test "success", %{tmp_dir: prefix} do
       {_, config} = Depot.Adapter.Local.configure(prefix: prefix)
 
       :ok = File.write(Path.join(prefix, "test.txt"), "Hello World")
@@ -103,7 +100,7 @@ defmodule Depot.Adapter.LocalTest do
       assert {:ok, "Hello World"} = Depot.Adapter.Local.read(config, "test.txt")
     end
 
-    test "stream options", %{prefix: prefix} do
+    test "stream options", %{tmp_dir: prefix} do
       {_, config} = Depot.Adapter.Local.configure(prefix: prefix)
 
       assert {:ok, %File.Stream{line_or_bytes: :line, modes: [:raw, :read_ahead, :binary]}} =
@@ -116,7 +113,7 @@ defmodule Depot.Adapter.LocalTest do
                Depot.Adapter.Local.read_stream(config, "test.txt", modes: [encoding: :utf8])
     end
 
-    test "stream success", %{prefix: prefix} do
+    test "stream success", %{tmp_dir: prefix} do
       {_, config} = Depot.Adapter.Local.configure(prefix: prefix)
 
       :ok = File.write(Path.join(prefix, "test.txt"), "Hello World")
@@ -129,7 +126,7 @@ defmodule Depot.Adapter.LocalTest do
   end
 
   describe "delete" do
-    test "success", %{prefix: prefix} do
+    test "success", %{tmp_dir: prefix} do
       {_, config} = Depot.Adapter.Local.configure(prefix: prefix)
 
       :ok = File.write(Path.join(prefix, "test.txt"), "Hello World")
@@ -139,7 +136,7 @@ defmodule Depot.Adapter.LocalTest do
       assert {:error, :enoent} = File.read(Path.join(prefix, "folder/test.txt"))
     end
 
-    test "successful even if no file to delete", %{prefix: prefix} do
+    test "successful even if no file to delete", %{tmp_dir: prefix} do
       {_, config} = Depot.Adapter.Local.configure(prefix: prefix)
 
       assert :ok = Depot.Adapter.Local.delete(config, "test.txt")

--- a/test/depot_test.exs
+++ b/test/depot_test.exs
@@ -8,18 +8,15 @@ defmodule DepotTest do
   end
 
   describe "filesystem without own processes" do
-    setup do
-      {:ok, prefix} = Briefly.create(directory: true)
-      {:ok, prefix: prefix}
-    end
+    @describetag :tmp_dir
 
-    test "user can write to filesystem", %{prefix: prefix} do
+    test "user can write to filesystem", %{tmp_dir: prefix} do
       filesystem = Depot.Adapter.Local.configure(prefix: prefix)
 
       assert :ok = Depot.write(filesystem, "test.txt", "Hello World")
     end
 
-    test "user can check if files exist on a filesystem", %{prefix: prefix} do
+    test "user can check if files exist on a filesystem", %{tmp_dir: prefix} do
       filesystem = Depot.Adapter.Local.configure(prefix: prefix)
 
       :ok = Depot.write(filesystem, "test.txt", "Hello World")
@@ -28,7 +25,7 @@ defmodule DepotTest do
       assert {:ok, :missing} = Depot.file_exists(filesystem, "not-test.txt")
     end
 
-    test "user can read from filesystem", %{prefix: prefix} do
+    test "user can read from filesystem", %{tmp_dir: prefix} do
       filesystem = Depot.Adapter.Local.configure(prefix: prefix)
 
       :ok = Depot.write(filesystem, "test.txt", "Hello World")
@@ -36,7 +33,7 @@ defmodule DepotTest do
       assert {:ok, "Hello World"} = Depot.read(filesystem, "test.txt")
     end
 
-    test "user can delete from filesystem", %{prefix: prefix} do
+    test "user can delete from filesystem", %{tmp_dir: prefix} do
       filesystem = Depot.Adapter.Local.configure(prefix: prefix)
 
       :ok = Depot.write(filesystem, "test.txt", "Hello World")
@@ -45,7 +42,7 @@ defmodule DepotTest do
       assert {:error, _} = Depot.read(filesystem, "test.txt")
     end
 
-    test "user can move files", %{prefix: prefix} do
+    test "user can move files", %{tmp_dir: prefix} do
       filesystem = Depot.Adapter.Local.configure(prefix: prefix)
 
       :ok = Depot.write(filesystem, "test.txt", "Hello World")
@@ -55,7 +52,7 @@ defmodule DepotTest do
       assert {:ok, "Hello World"} = Depot.read(filesystem, "not-test.txt")
     end
 
-    test "user can copy files", %{prefix: prefix} do
+    test "user can copy files", %{tmp_dir: prefix} do
       filesystem = Depot.Adapter.Local.configure(prefix: prefix)
 
       :ok = Depot.write(filesystem, "test.txt", "Hello World")
@@ -65,7 +62,7 @@ defmodule DepotTest do
       assert {:ok, "Hello World"} = Depot.read(filesystem, "not-test.txt")
     end
 
-    test "user can list files", %{prefix: prefix} do
+    test "user can list files", %{tmp_dir: prefix} do
       filesystem = Depot.Adapter.Local.configure(prefix: prefix)
 
       :ok = Depot.write(filesystem, "test.txt", "Hello World")
@@ -80,12 +77,9 @@ defmodule DepotTest do
   end
 
   describe "module based filesystem without own processes" do
-    setup do
-      {:ok, prefix} = Briefly.create(directory: true)
-      {:ok, prefix: prefix}
-    end
+    @describetag :tmp_dir
 
-    test "user can write to filesystem", %{prefix: prefix} do
+    test "user can write to filesystem", %{tmp_dir: prefix} do
       defmodule Local.WriteTest do
         use Depot.Filesystem,
           adapter: Depot.Adapter.Local,
@@ -95,7 +89,7 @@ defmodule DepotTest do
       assert :ok = Local.WriteTest.write("test.txt", "Hello World")
     end
 
-    test "user can check if files exist on a filesystem", %{prefix: prefix} do
+    test "user can check if files exist on a filesystem", %{tmp_dir: prefix} do
       defmodule Local.FileExistsTest do
         use Depot.Filesystem,
           adapter: Depot.Adapter.Local,
@@ -108,7 +102,7 @@ defmodule DepotTest do
       assert {:ok, :missing} = Local.FileExistsTest.file_exists("not-test.txt")
     end
 
-    test "user can read from filesystem", %{prefix: prefix} do
+    test "user can read from filesystem", %{tmp_dir: prefix} do
       defmodule Local.ReadTest do
         use Depot.Filesystem,
           adapter: Depot.Adapter.Local,
@@ -120,7 +114,7 @@ defmodule DepotTest do
       assert {:ok, "Hello World"} = Local.ReadTest.read("test.txt")
     end
 
-    test "user can delete from filesystem", %{prefix: prefix} do
+    test "user can delete from filesystem", %{tmp_dir: prefix} do
       defmodule Local.DeleteTest do
         use Depot.Filesystem,
           adapter: Depot.Adapter.Local,
@@ -133,7 +127,7 @@ defmodule DepotTest do
       assert {:error, _} = Local.DeleteTest.read("test.txt")
     end
 
-    test "user can move files", %{prefix: prefix} do
+    test "user can move files", %{tmp_dir: prefix} do
       defmodule Local.MoveTest do
         use Depot.Filesystem,
           adapter: Depot.Adapter.Local,
@@ -147,7 +141,7 @@ defmodule DepotTest do
       assert {:ok, "Hello World"} = Local.MoveTest.read("not-test.txt")
     end
 
-    test "user can copy files", %{prefix: prefix} do
+    test "user can copy files", %{tmp_dir: prefix} do
       defmodule Local.CopyTest do
         use Depot.Filesystem,
           adapter: Depot.Adapter.Local,
@@ -161,7 +155,7 @@ defmodule DepotTest do
       assert {:ok, "Hello World"} = Local.CopyTest.read("not-test.txt")
     end
 
-    test "user can list files", %{prefix: prefix} do
+    test "user can list files", %{tmp_dir: prefix} do
       defmodule Local.ListContentsTest do
         use Depot.Filesystem,
           adapter: Depot.Adapter.Local,
@@ -363,13 +357,14 @@ defmodule DepotTest do
   end
 
   describe "filesystem independant" do
-    setup do
-      {:ok, prefix} = Briefly.create(directory: true)
+    @describetag :tmp_dir
+
+    setup %{tmp_dir: prefix} do
       filesystem = Depot.Adapter.Local.configure(prefix: prefix)
       {:ok, filesystem: filesystem}
     end
 
-    test "reads configuration from :otp_app" do
+    test "reads configuration from :otp_app", context do
       configuration = [
         adapter: Depot.Adapter.Local,
         prefix: "ziKK7t5LzV5XiJjYh30KxCLorRXqLwwEnZYJ"
@@ -402,9 +397,12 @@ defmodule DepotTest do
   end
 
   describe "copying between different filesystems" do
-    setup do
-      {:ok, prefix_a} = Briefly.create(directory: true)
-      {:ok, prefix_b} = Briefly.create(directory: true)
+    @describetag :tmp_dir
+
+    setup %{tmp_dir: prefix} do
+      prefix_a = Path.join(prefix, "a")
+      prefix_b = Path.join(prefix, "b")
+
       {:ok, prefixes: [prefix_a, prefix_b]}
     end
 


### PR DESCRIPTION
Fix for #16 

Mostly straightforward, except for:

1. I couldn't find a way to use `tmp_dir` in a doctest. This probably stretches past the limit of what doctest is for anyways. I was able to use `System.tmp_dir!` though
2. When running `mix deps.clean --unlock --unused` to remove briefly, it looks like it also decided to remove `earmark` (which appears unused in `master`)