### PR TITLE
Add :path key to Depot.Stat.File

### DIFF
--- a/lib/depot/adapter/local.ex
+++ b/lib/depot/adapter/local.ex
@@ -178,8 +178,17 @@ defmodule Depot.Adapter.Local do
             stat.type in [:directory, :regular] do
           struct =
             case stat.type do
-              :directory -> Depot.Stat.Dir
-              :regular -> Depot.Stat.File
+              :directory ->
+                Depot.Stat.Dir
+
+              :regular ->
+                filepath =
+                  case Depot.RelativePath.normalize(Path.relative(path)) do
+                    {:ok, normalized_path} -> normalized_path
+                    {:error, _} -> path
+                  end
+
+                %Depot.Stat.File{path: filepath}
             end
 
           struct!(struct,

--- a/lib/depot/adapter_test.ex
+++ b/lib/depot/adapter_test.ex
@@ -115,12 +115,17 @@ defmodule Depot.AdapterTest do
 
         assert in_list(list, %Depot.Stat.Dir{name: "test"})
         assert in_list(list, %Depot.Stat.Dir{name: "folder"})
-        assert in_list(list, %Depot.Stat.File{name: "test.txt"})
-        assert in_list(list, %Depot.Stat.File{name: "test-1.txt"})
+        assert in_list(list, %Depot.Stat.File{name: "test.txt", path: ""})
+        assert in_list(list, %Depot.Stat.File{name: "test-1.txt", path: ""})
 
         refute in_list(list, %Depot.Stat.File{name: "folder/test-1.txt"})
 
         assert length(list) == 4
+
+        {:ok, list} = Depot.list_contents(filesystem, "folder/")
+
+        assert length(list) == 1
+        assert in_list(list, %Depot.Stat.File{path: "folder/", name: "test-1.txt"})
       end
 
       test "directory listings include visibility", %{filesystem: filesystem} do

--- a/lib/depot/adapter_test.ex
+++ b/lib/depot/adapter_test.ex
@@ -1,10 +1,4 @@
 defmodule Depot.AdapterTest do
-  defmacro in_list(list, match) do
-    quote do
-      Enum.any?(unquote(list), &match?(unquote(match), &1))
-    end
-  end
-
   defp tests do
     quote do
       test "user can write to filesystem", %{filesystem: filesystem} do
@@ -113,19 +107,19 @@ defmodule Depot.AdapterTest do
 
         {:ok, list} = Depot.list_contents(filesystem, ".")
 
-        assert in_list(list, %Depot.Stat.Dir{name: "test"})
-        assert in_list(list, %Depot.Stat.Dir{name: "folder"})
-        assert in_list(list, %Depot.Stat.File{name: "test.txt", path: ""})
-        assert in_list(list, %Depot.Stat.File{name: "test-1.txt", path: ""})
+        assert_in_list list, %Depot.Stat.Dir{name: "test"}
+        assert_in_list list, %Depot.Stat.Dir{name: "folder"}
+        assert_in_list list, %Depot.Stat.File{name: "test.txt", path: ""}
+        assert_in_list list, %Depot.Stat.File{name: "test-1.txt", path: ""}
 
-        refute in_list(list, %Depot.Stat.File{name: "folder/test-1.txt"})
+        refute_in_list(list, %Depot.Stat.File{name: "folder/test-1.txt"})
 
         assert length(list) == 4
 
         {:ok, list} = Depot.list_contents(filesystem, "folder/")
 
         assert length(list) == 1
-        assert in_list(list, %Depot.Stat.File{path: "folder/", name: "test-1.txt"})
+        assert_in_list list, %Depot.Stat.File{path: "folder/", name: "test-1.txt"}
       end
 
       test "directory listings include visibility", %{filesystem: filesystem} do
@@ -136,10 +130,10 @@ defmodule Depot.AdapterTest do
 
         {:ok, list} = Depot.list_contents(filesystem, ".")
 
-        assert in_list(list, %Depot.Stat.Dir{name: "visible-dir", visibility: :public})
-        assert in_list(list, %Depot.Stat.Dir{name: "invisible-dir", visibility: :private})
-        assert in_list(list, %Depot.Stat.File{name: "visible.txt", visibility: :public})
-        assert in_list(list, %Depot.Stat.File{name: "invisible.txt", visibility: :private})
+        assert_in_list list, %Depot.Stat.Dir{name: "visible-dir", visibility: :public}
+        assert_in_list list, %Depot.Stat.Dir{name: "invisible-dir", visibility: :private}
+        assert_in_list list, %Depot.Stat.File{name: "visible.txt", visibility: :public}
+        assert_in_list list, %Depot.Stat.File{name: "invisible.txt", visibility: :private}
 
         assert length(list) == 4
       end
@@ -230,7 +224,6 @@ defmodule Depot.AdapterTest do
       describe "common adapter tests" do
         setup unquote(block)
 
-        import Depot.AdapterTest, only: [in_list: 2]
         unquote(tests())
       end
     end
@@ -241,7 +234,6 @@ defmodule Depot.AdapterTest do
       describe "common adapter tests" do
         setup unquote(context), unquote(block)
 
-        import Depot.AdapterTest, only: [in_list: 2]
         unquote(tests())
       end
     end

--- a/lib/depot/stat/file.ex
+++ b/lib/depot/stat/file.ex
@@ -1,3 +1,3 @@
 defmodule Depot.Stat.File do
-  defstruct name: nil, size: nil, mtime: nil, visibility: nil
+  defstruct name: nil, path: nil, size: nil, mtime: nil, visibility: nil
 end

--- a/mix.exs
+++ b/mix.exs
@@ -8,6 +8,7 @@ defmodule Depot.MixProject do
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
+      elixirc_paths: elixirc_paths(Mix.env()),
       description: description(),
       package: package(),
       name: "Depot",
@@ -28,6 +29,9 @@ defmodule Depot.MixProject do
       links: %{"GitHub" => "https://github.com/elixir-depot/depot"}
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp docs do
     [

--- a/test/depot/adapter/in_memory_test.exs
+++ b/test/depot/adapter/in_memory_test.exs
@@ -3,6 +3,12 @@ defmodule Depot.Adapter.InMemoryTest do
   import Depot.AdapterTest
   doctest Depot.Adapter.InMemory
 
+  defmacrop assert_in_list(list, match) do
+    quote do
+      assert Enum.any?(unquote(list), &match?(unquote(match), &1))
+    end
+  end
+
   adapter_test %{test: test} do
     filesystem = Depot.Adapter.InMemory.configure(name: test)
     start_supervised(filesystem)
@@ -66,6 +72,37 @@ defmodule Depot.Adapter.InMemoryTest do
                Depot.Adapter.InMemory.read_stream(config, "test.txt", [])
 
       assert Enum.into(stream, <<>>) == "Hello World"
+    end
+  end
+
+  describe "listing contents" do
+    test "lists files and folders", %{test: test} do
+      {_, config} = filesystem = Depot.Adapter.InMemory.configure(name: test)
+
+      start_supervised(filesystem)
+
+      :ok = Depot.Adapter.InMemory.write(config, "test.txt", "Hello World", [])
+      :ok = Depot.Adapter.InMemory.write(config, "folder/test.txt", "Hello World", [])
+
+      {:ok, contents} = Depot.Adapter.InMemory.list_contents(config, "/")
+
+      assert length(contents) == 2
+      assert_in_list contents, %Depot.Stat.File{name: "test.txt", path: ""}
+      assert_in_list contents, %Depot.Stat.Dir{name: "folder"}
+    end
+
+    test "lists files include a path relative to the filesystem", %{test: test} do
+      {_, config} = filesystem = Depot.Adapter.InMemory.configure(name: test)
+
+      start_supervised(filesystem)
+
+      :ok =
+        Depot.Adapter.InMemory.write(config, "deeply/nested/folder/test.txt", "Hello World", [])
+
+      {:ok, contents} = Depot.Adapter.InMemory.list_contents(config, "/deeply/nested/folder")
+
+      assert length(contents) == 1
+      assert_in_list contents, %Depot.Stat.File{name: "test.txt", path: "deeply/nested/folder"}
     end
   end
 

--- a/test/depot/adapter/in_memory_test.exs
+++ b/test/depot/adapter/in_memory_test.exs
@@ -1,13 +1,8 @@
 defmodule Depot.Adapter.InMemoryTest do
   use ExUnit.Case, async: true
   import Depot.AdapterTest
+  import Depot.ListAssertions
   doctest Depot.Adapter.InMemory
-
-  defmacrop assert_in_list(list, match) do
-    quote do
-      assert Enum.any?(unquote(list), &match?(unquote(match), &1))
-    end
-  end
 
   adapter_test %{test: test} do
     filesystem = Depot.Adapter.InMemory.configure(name: test)

--- a/test/depot/adapter/local_test.exs
+++ b/test/depot/adapter/local_test.exs
@@ -2,18 +2,13 @@ defmodule Depot.Adapter.LocalTest do
   use ExUnit.Case, async: true
   use Bitwise, only_operators: true
   import Depot.AdapterTest
+  import Depot.ListAssertions
   doctest Depot.Adapter.Local
 
   @moduletag :tmp_dir
 
   def match_mode(input, match) do
     (input &&& 0o777) == match
-  end
-
-  defmacrop assert_in_list(list, match) do
-    quote do
-      assert Enum.any?(unquote(list), &match?(unquote(match), &1))
-    end
   end
 
   adapter_test %{tmp_dir: prefix} do

--- a/test/depot_test.exs
+++ b/test/depot_test.exs
@@ -1,11 +1,6 @@
 defmodule DepotTest do
   use ExUnit.Case, async: true
-
-  defmacrop assert_in_list(list, match) do
-    quote do
-      assert Enum.any?(unquote(list), &match?(unquote(match), &1))
-    end
-  end
+  import Depot.ListAssertions
 
   describe "filesystem without own processes" do
     @describetag :tmp_dir

--- a/test/support/list_assertions.ex
+++ b/test/support/list_assertions.ex
@@ -1,0 +1,7 @@
+defmodule Depot.ListAssertions do
+  defmacro assert_in_list(list, match) do
+    quote do
+      assert Enum.any?(unquote(list), &match?(unquote(match), &1))
+    end
+  end
+end

--- a/test/support/list_assertions.ex
+++ b/test/support/list_assertions.ex
@@ -4,4 +4,10 @@ defmodule Depot.ListAssertions do
       assert Enum.any?(unquote(list), &match?(unquote(match), &1))
     end
   end
+
+  defmacro refute_in_list(list, match) do
+    quote do
+      refute Enum.any?(unquote(list), &match?(unquote(match), &1))
+    end
+  end
 end


### PR DESCRIPTION
Addresses #10

Adds the `:path` key to `Depot.Stat.File`. This is equivalent to the `dirname` of the file.

Here's an example:

```elixir
iex> tmp_dir = System.tmp_dir!()
iex> filesystem = Depot.Adapter.Local.configure(prefix: tmp_dir)

iex> :ok = Depot.write(filesystem, "test.txt", "hello")
iex> :ok = Depot.write(filesystem, "blah/test2.txt", "hello")

# test.txt
# blah
# └── test2.txt

iex> {:ok, contents} = Depot.list_contents(filesystem, ".")
{:ok,
 [
   %Depot.Stat.File{
     mtime: 1633556057,
     name: "test.txt",
     path: "/var/folders/l1/y093w_z16kl06mjbhm97cx6c0000gn/T",
     size: 5,
     visibility: :public
   },
   %Depot.Stat.Dir{
     mtime: 1633556061,
     name: "blah",
     size: 160,
     visibility: :public
   }
 ]}

iex> {:ok, contents} = Depot.list_contents(filesystem, "blah")
{:ok,
 [
   %Depot.Stat.File{
     mtime: 1633556061,
     name: "test2.txt",
     path: "/var/folders/l1/y093w_z16kl06mjbhm97cx6c0000gn/T/blah",
     size: 5,
     visibility: :public
   }
 ]}
```